### PR TITLE
Fixed redundant function call in StockOutTable.js

### DIFF
--- a/src/components/StockOutTable.js
+++ b/src/components/StockOutTable.js
@@ -33,8 +33,9 @@ const StockOutTable = () => {
   };
 
   // Initialize authentication state from localStorage
-  const [isAuthenticated, setIsAuthenticated] = useState(checkExistingAuth());
-  const [showLoginModal, setShowLoginModal] = useState(!checkExistingAuth());
+const isAuth = checkExistingAuth();
+const [isAuthenticated, setIsAuthenticated] = useState(isAuth);
+const [showLoginModal, setShowLoginModal] = useState(!isAuth);
   
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION

This PR fixes a redundant function call issue in `StockOutTable.js`, where `checkExistingAuth()` was called twice during state initialization. The function reads from `localStorage` and parses JSON, leading to unnecessary computations.  

#### **Changes Made**  
- Stored the result of `checkExistingAuth()` in a variable `isAuth` to prevent duplicate calls.  
- Used the stored value to initialize both `isAuthenticated` and `showLoginModal` states.  
- Improved performance and consistency.  

**Before:**  
```javascript
const [isAuthenticated, setIsAuthenticated] = useState(checkExistingAuth());
const [showLoginModal, setShowLoginModal] = useState(!checkExistingAuth());
```
**After:**  
```javascript
const isAuth = checkExistingAuth();
const [isAuthenticated, setIsAuthenticated] = useState(isAuth);
const [showLoginModal, setShowLoginModal] = useState(!isAuth);
```

#### **Issue Reference**  
Closes #1   

#### **Testing Done**  

- [x] Verified that the authentication state initializes correctly.  
- [x] Compiled Successfully with no errors.